### PR TITLE
Add GH Action yml and 2 quick fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Build Documentation using MkDocs
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # This might not be what we want, it might run when a PR is *submitted*, rather than merged, docs seem unclear
+    branches: [master]
+
+jobs:
+  build:
+    name: Build and Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Master
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
+      - name: Deploy
+        run: |
+          git pull
+          mkdocs gh-deploy

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # CoderDojo Twin Cities Thunkable Resources
 
 This GitHub repository is for sharing teaching resources to teach Thunkable.
-Thunkable is used to build moble applications on both Android and iPhone.
+Thunkable is used to build mobile applications on both Android and iPhone.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ copyright: 'All content is licensed under Creative Commons Sharealike non-commer
 theme:
   name: material
   logo: img/coderdojo-logo.jpg
-  favicon: img/favicon.png
+  favicon: img/favicon.ico
   palette:
     primary: '#642580'
     accent: '#41BAC1'


### PR DESCRIPTION
Fixes:
* Correct the favicon path (also needs to be changed in other sites as well)
* Correct typo in main page

Copy/pasted the GitHub action yml workflow from the Python page. Something to check, the:
```
on:
  pull_request:
```
This might run the workflow when a PR is opened, rather than when a PR is merged. In [the docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request):
`By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened`.

We could confirm if we have a workflow active and open a PR without merging, and see if the workflow runs. In Jenkins, a PR merge into a branch counts as a push to a branch, so this:

```
on:
  push:
    branches: [master]
```
might be enough to run the workflow on PR merges to master.